### PR TITLE
Add protoquill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,9 @@ val zioZMXVersion = "0.0.8"
 val zioLoggingVersion = "0.5.12"
 val logbackVersion = "1.2.6"
 val zioConfigVersion = "1.0.9"
+val testcontainersVersion      = "1.16.0"
+val testcontainersScalaVersion = "0.39.8"
+val quillVersion = "3.7.2.Beta1.4"
 
 // This build is for this Giter8 template.
 // To test the template run `g8` or `g8Test` from the sbt session.
@@ -15,6 +18,16 @@ lazy val root = (project in file("."))
     resolvers += "Sonatype OSS Snapshots s01" at "https://s01.oss.sonatype.org/content/repositories/snapshots",
     name := "zio-quickstart",
     libraryDependencies ++= Seq(
+      "io.getquill" %% "quill-jdbc" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "io.getquill" %% "quill-jdbc-zio" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "io.getquill" %% "quill-jasync-postgres" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "org.postgresql" % "postgresql" % "42.2.23",
       "dev.zio" %% "zio" % zioVersion,
       "dev.zio" %% "zio-streams" % zioVersion,
       "io.d11"  %% "zhttp" % zioHttpVersion,
@@ -29,6 +42,11 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-test" % zioVersion % Test,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
       "dev.zio" %% "zio-test-junit" % zioVersion % Test,
+      "com.dimafeng"      %% "testcontainers-scala-postgresql" % testcontainersScalaVersion % Test,
+      "org.testcontainers" % "testcontainers"                  % testcontainersVersion      % Test,
+      "org.testcontainers" % "database-commons"                % testcontainersVersion      % Test,
+      "org.testcontainers" % "postgresql"                      % testcontainersVersion      % Test,
+      "org.testcontainers" % "jdbc"                            % testcontainersVersion      % Test,
       "dev.zio" %% "zio-test-magnolia" % zioVersion % Test,
     ),
     test in Test := {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+# run with "docker compose up -d"
+version: '3.7'
+
+services:
+  postgres:
+    image: postgres:latest
+    restart: always
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+      - ./src/main/resources/init.sql:/docker-entrypoint-initdb.d/init.sql
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=quickstart-db
+    ports:
+      - "5432:5432"

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,6 +7,9 @@ $endif$
 val zioLoggingVersion = "0.5.12"
 val logbackVersion = "1.2.6"
 val zioConfigVersion = "1.0.9"
+val testcontainersVersion      = "1.16.0"
+val testcontainersScalaVersion = "0.39.8"
+val quillVersion = "3.7.2.Beta1.4"
 
 lazy val root = (project in file("."))
   .settings(
@@ -23,6 +26,16 @@ lazy val root = (project in file("."))
     resolvers += "Sonatype OSS Snapshots s01" at "https://s01.oss.sonatype.org/content/repositories/snapshots",
     name := "zio-quickstart",
     libraryDependencies ++= Seq(
+      "io.getquill" %% "quill-jdbc" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "io.getquill" %% "quill-jdbc-zio" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "io.getquill" %% "quill-jasync-postgres" % quillVersion excludeAll (
+        ExclusionRule(organization = "org.scala-lang.modules")
+      ),
+      "org.postgresql" % "postgresql" % "42.2.23",
       "dev.zio" %% "zio" % zioVersion,
       "dev.zio" %% "zio-streams" % zioVersion,
       "io.d11" %% "zhttp" % zioHttpVersion,
@@ -39,6 +52,11 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-test" % zioVersion % Test,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
       "dev.zio" %% "zio-test-junit" % zioVersion % Test,
+      "com.dimafeng"      %% "testcontainers-scala-postgresql" % testcontainersScalaVersion % Test,
+      "org.testcontainers" % "testcontainers"                  % testcontainersVersion      % Test,
+      "org.testcontainers" % "database-commons"                % testcontainersVersion      % Test,
+      "org.testcontainers" % "postgresql"                      % testcontainersVersion      % Test,
+      "org.testcontainers" % "jdbc"                            % testcontainersVersion      % Test,
       "dev.zio" %% "zio-test-magnolia" % zioVersion % Test,
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),

--- a/src/main/g8/src/main/resources/application.conf
+++ b/src/main/g8/src/main/resources/application.conf
@@ -9,3 +9,14 @@ diagnostics-server-config {
     debug            = "false"
 }
 $endif$
+
+testPostgresDB {
+    dataSource {
+        user=postgres
+        databaseName=quickstart-db
+        password=postgres
+        portNumber=5432
+        serverName=0.0.0.0
+    }
+    dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
+}

--- a/src/main/g8/src/main/resources/init.sql
+++ b/src/main/g8/src/main/resources/init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS items(
+    id serial PRIMARY KEY, 
+    description VARCHAR(255)
+);

--- a/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/src/main/scala/$package$/Main.scala
@@ -14,6 +14,9 @@ import zio.zmx.diagnostics._
 $endif$
 import zio.config._
 import zio.clock.Clock
+import io.getquill.context.ZioJdbc.QDataSource
+import zio.blocking.Blocking
+import io.getquill.context.ZioJdbc.QConnection
 import zio.logging._
 import $package$.config.configuration.ServerConfig
 import $package$.service._
@@ -31,7 +34,9 @@ object Main extends zio.App:
     logLevel = LogLevel.Info,
     format = LogFormat.ColoredLogFormat(),
   ) >>> Logging.withRootLoggerName("$name$")
-  private val repoLayer = Random.live >>> ItemRepositoryLive.layer
+  private val connection = 
+    Blocking.live >>> (QDataSource.fromPrefix("testPostgresDB") >>> QDataSource.toConnection)
+  private val repoLayer = (loggingEnv ++ connection) >>> ItemRepositoryLive.layer
   $if(add_websocket_endpoint.truthy)$
   private val subscriberLayer = ZLayer.fromEffect(Ref.make(List.empty)) >>> SubscriberServiceLive.layer
   $endif$

--- a/src/main/g8/src/main/scala/$package$/repo/ItemRepository.scala
+++ b/src/main/g8/src/main/scala/$package$/repo/ItemRepository.scala
@@ -13,8 +13,6 @@ trait ItemRepository:
 
   def getById(id: ItemId): IO[RepositoryError, Option[Item]]
 
-  def getByIds(ids: Set[ItemId]): IO[RepositoryError, List[Item]]
-
   def update(id: ItemId, item: Item): IO[RepositoryError, Unit]
 
 object ItemRepository:
@@ -25,7 +23,5 @@ object ItemRepository:
   def getAll(): ZIO[Has[ItemRepository], RepositoryError, List[Item]] = ZIO.serviceWith[ItemRepository](_.getAll())
 
   def getById(id: ItemId): ZIO[Has[ItemRepository], RepositoryError, Option[Item]] = ZIO.serviceWith[ItemRepository](_.getById(id))
-
-  def getByIds(ids: Set[ItemId]): ZIO[Has[ItemRepository], RepositoryError, List[Item]] = ZIO.serviceWith[ItemRepository](_.getByIds(ids))
 
   def update(id: ItemId, item: Item): ZIO[Has[ItemRepository], RepositoryError, Unit] = ZIO.serviceWith[ItemRepository](_.update(id, item))

--- a/src/main/g8/src/main/scala/$package$/repo/ItemRepositoryLive.scala
+++ b/src/main/g8/src/main/scala/$package$/repo/ItemRepositoryLive.scala
@@ -1,48 +1,88 @@
 package $package$.repo
 
-import zio.random._
-import zio.console._
 import zio._
+import io.getquill._
+import io.getquill.context.ZioJdbc._
+import zio.blocking.Blocking
+import zio.logging.Logging
+import zio.logging.Logger
+import java.sql.SQLException
+import io.getquill.context.Context
+import io.getquill.context.qzio.ZioJdbcContext
 import $package$.domain._
 import $package$.domain.DomainError.RepositoryError
 
-// TODO switch Random and Ref[Map[ItemId, Item]] with some DBClient and store to DB not to in memory Map
-final case class ItemRepositoryLive(
-    random: Random.Service,
-    dataRef: Ref[Map[ItemId, Item]],
+final class ItemRepositoryLive(
+    log: Logger[String],
+    connection: QConnection,
+    ctx: PostgresZioJdbcContext[PluralizedTableNames],
   ) extends ItemRepository:
 
+  import ctx._
+
+  // TODO return generated ID with the use of "returningGenerated" method
+  // issue opened https://github.com/getquill/protoquill/issues/22
   def add(description: String): IO[RepositoryError, ItemId] =
-    for {
-      itemId <- random.nextLong.map(_.abs)
-      id = ItemId(itemId)
-      _ <- dataRef.update(map => map + (id -> Item(id, description)))
-    } yield id
+    ctx
+      .transaction(for {
+        _ <- ctx.run(
+          quote {
+            query[Item].insert(_.description -> lift(description))
+          }
+        )
+        result <- ctx.run(
+          quote {
+            query[Item].filter(_.description == lift(description)).map(_.id)
+          }
+        )
+        generatedId = result.headOption.fold(0L)(_.value)
+      } yield (ItemId(generatedId)))
+      .mapError(e => new RepositoryError(e))
+      .provide(connection)
 
   def delete(id: ItemId): IO[RepositoryError, Unit] =
-    dataRef.update(map => map - id)
+    ctx
+      .run(quote(query[Item].filter(i => i.id == lift(id)).delete))
+      .mapError(e => new RepositoryError(e))
+      .provide(connection)
+      .unit
 
   def getAll(): IO[RepositoryError, List[Item]] =
-    for {
-      itemsMap <- dataRef.get
-    } yield (itemsMap.view.values.toList)
+    ctx
+      .run(quote {
+        query[Item]
+      })
+      .provide(connection)
+      .mapError(e => new RepositoryError(e))
 
   def getById(id: ItemId): IO[RepositoryError, Option[Item]] =
-    for {
-      values <- dataRef.get
-    } yield (values.get(id))
+    ctx
+      .run(quote {
+        query[Item].filter(_.id == lift(id))
+      })
+      .map(_.headOption)
+      .mapError(e => new RepositoryError(e))
+      .provide(connection)
 
-  def getByIds(ids: Set[ItemId]): IO[RepositoryError, List[Item]] =
-    for {
-      values <- dataRef.get
-    } yield (values.filter(id => ids.contains(id._1)).view.values.toList)
-
-  def update(id: ItemId, item: Item): IO[RepositoryError, Unit] =
-    dataRef.update(map => map + (id -> item.copy(id = id)))
+  def update(itemId: ItemId, value: Item): IO[RepositoryError, Unit] =
+    ctx
+      .run(quote {
+        query[Item]
+          .filter(i => i.id == lift(itemId))
+          .update(_.description -> lift(value.description))
+      })
+      .mapError(e => new RepositoryError(e))
+      .provide(connection)
+      .unit
 
 object ItemRepositoryLive:
-  val layer: ZLayer[Has[Random.Service], Nothing, Has[ItemRepository]] =
+
+  val layer: ZLayer[Logging with QConnection, Nothing, Has[ItemRepository]] =
     (for {
-      random  <- ZIO.service[Random.Service]
-      dataRef <- Ref.make(Map.empty[ItemId, Item])
-    } yield (ItemRepositoryLive(random, dataRef))).toLayer
+      logging <- ZIO.service[Logger[String]]
+      connection <- ZIO.environment[QConnection]
+    } yield (ItemRepositoryLive(
+      logging,
+      connection,
+      new PostgresZioJdbcContext(PluralizedTableNames),
+    ))).toLayer

--- a/src/main/g8/src/main/scala/$package$/service/$if(add_websocket_endpoint.truthy)$SubscriberServiceLive.scala$endif$
+++ b/src/main/g8/src/main/scala/$package$/service/$if(add_websocket_endpoint.truthy)$SubscriberServiceLive.scala$endif$
@@ -4,7 +4,7 @@ import $package$.domain.ItemId
 import zio._
 import zio.stream._
 
-final case class SubscriberServiceLive(deletedEventsSubscribers: Ref[List[Queue[ItemId]]])
+final class SubscriberServiceLive(deletedEventsSubscribers: Ref[List[Queue[ItemId]]])
     extends SubscriberService:
   override def getQueue: UIO[List[Queue[ItemId]]] = deletedEventsSubscribers.get
   override def publishDeleteEvents(deletedItemId: ItemId): IO[Nothing, List[Boolean]] =

--- a/src/main/g8/src/main/scala/$package$/service/ItemServiceLive.scala
+++ b/src/main/g8/src/main/scala/$package$/service/ItemServiceLive.scala
@@ -6,7 +6,7 @@ import $package$.domain._
 import $package$.domain.DomainError.BusinessError
 import $package$.repo._
 
-final case class ItemServiceLive(repo: ItemRepository $if(add_websocket_endpoint.truthy)$, subscriber: SubscriberService $endif$) extends ItemService:
+final class ItemServiceLive(repo: ItemRepository $if(add_websocket_endpoint.truthy)$, subscriber: SubscriberService $endif$) extends ItemService:
   def addItem(description: String): IO[DomainError, ItemId] =
     repo.add(description)
 

--- a/src/main/g8/src/test/resources/item_schema.sql
+++ b/src/main/g8/src/test/resources/item_schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS items(
+    id serial PRIMARY KEY, 
+    description VARCHAR(255)
+);

--- a/src/main/g8/src/test/scala/$package$/api/$if(add_websocket_endpoint.truthy)$WebSocketRouteSpec.scala$endif$
+++ b/src/main/g8/src/test/scala/$package$/api/$if(add_websocket_endpoint.truthy)$WebSocketRouteSpec.scala$endif$
@@ -21,7 +21,7 @@ import $package$.domain._
 
 object WebSocketRouteSpec extends DefaultRunnableSpec:
   private val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
-  val repoLayer = (Console.live ++ Random.live) >>> ItemRepositoryLive.layer
+  val repoLayer = (Console.live ++ Random.live) >>> InMemoryItemRepository.layer
   val subscriberLayer = ZLayer.fromEffect(Ref.make(List.empty)) >>> SubscriberServiceLive.layer
   val businessLayer = (repoLayer ++ subscriberLayer) >>> ItemServiceLive.layer
   val socketOpen = SocketApp.open(Socket.succeed(WebSocketFrame.text("ws openned!")))

--- a/src/main/g8/src/test/scala/$package$/repo/InMemoryItemRepository.scala
+++ b/src/main/g8/src/test/scala/$package$/repo/InMemoryItemRepository.scala
@@ -1,0 +1,47 @@
+package $package$.repo
+
+import zio.random._
+import zio.console._
+import zio._
+import $package$.domain._
+import $package$.domain.DomainError.RepositoryError
+
+final class InMemoryItemRepository(
+    random: Random.Service,
+    dataRef: Ref[Map[ItemId, Item]],
+  ) extends ItemRepository:
+
+  def add(description: String): IO[RepositoryError, ItemId] =
+    for {
+      itemId <- random.nextLong.map(_.abs)
+      id = ItemId(itemId)
+      _ <- dataRef.update(map => map + (id -> Item(id, description)))
+    } yield id
+
+  def delete(id: ItemId): IO[RepositoryError, Unit] =
+    dataRef.update(map => map - id)
+
+  def getAll(): IO[RepositoryError, List[Item]] =
+    for {
+      itemsMap <- dataRef.get
+    } yield (itemsMap.view.values.toList)
+
+  def getById(id: ItemId): IO[RepositoryError, Option[Item]] =
+    for {
+      values <- dataRef.get
+    } yield (values.get(id))
+
+  def getByIds(ids: Set[ItemId]): IO[RepositoryError, List[Item]] =
+    for {
+      values <- dataRef.get
+    } yield (values.filter(id => ids.contains(id._1)).view.values.toList)
+
+  def update(id: ItemId, item: Item): IO[RepositoryError, Unit] =
+    dataRef.update(map => map + (id -> item.copy(id = id)))
+
+object InMemoryItemRepository:
+  val layer: ZLayer[Has[Random.Service], Nothing, Has[ItemRepository]] =
+    (for {
+      random  <- ZIO.service[Random.Service]
+      dataRef <- Ref.make(Map.empty[ItemId, Item])
+    } yield (InMemoryItemRepository(random, dataRef))).toLayer

--- a/src/main/g8/src/test/scala/$package$/repo/ItemRepoMock.scala
+++ b/src/main/g8/src/test/scala/$package$/repo/ItemRepoMock.scala
@@ -1,18 +1,17 @@
 package $package$.repo
 
+import zio._
 import zio.test.mock._
 import $package$.domain.ItemId
 import $package$.domain.Item
 import $package$.domain.DomainError._
 import $package$.repo.ItemRepository
-import zio._
 
 object ItemRepoMock extends Mock[Has[ItemRepository]]:
   object Add extends Effect[String, Nothing, ItemId]
   object Delete extends Effect[ItemId, Nothing, Unit]
   object GetAll extends Effect[Unit, Nothing, List[Item]]
   object GetById extends Effect[ItemId, Nothing, Option[Item]]
-  object GetByIds extends Effect[Set[ItemId], Nothing, List[Item]]
   object Update extends Effect[(ItemId, Item), Nothing, Unit]
 
   val compose: URLayer[Has[Proxy], Has[ItemRepository]] =
@@ -26,8 +25,6 @@ object ItemRepoMock extends Mock[Has[ItemRepository]]:
           def getAll(): IO[RepositoryError, List[Item]] = proxy(GetAll)
 
           def getById(id: ItemId): IO[RepositoryError, Option[Item]] = proxy(GetById, id)
-
-          def getByIds(ids: Set[ItemId]): IO[RepositoryError, List[Item]] = proxy(GetByIds, ids)
 
           def update(id: ItemId, item: Item): IO[RepositoryError, Unit] = proxy(Update, id, item)
         }

--- a/src/main/g8/src/test/scala/$package$/repo/ItemRepositoryLiveSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/repo/ItemRepositoryLiveSpec.scala
@@ -1,0 +1,64 @@
+package $package$.repo
+
+import zio.test._
+import zio.test.Assertion._
+import zio.blocking._
+import zio.clock._
+import zio.test.TestAspect._
+import zio._
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import zio.logging.Logging
+import zio.test.environment.TestEnvironment
+import io.getquill.context.ZioJdbc.QConnection
+import $package$.repo.postgresql._
+import $package$.domain._
+
+object PostgresRunnableSpec extends DefaultRunnableSpec:
+
+  val containerLayer = PostgresContainer.make() ++ Blocking.live ++ Clock.live
+
+  val connectionLayer =
+    Blocking.live ++ (Blocking.live >>> containerLayer >>> ConnectionBuilderLive
+      .layer
+      .flatMap(builder => ZLayer.fromManaged(builder.get.connection)))
+
+  val repoLayer = ItemRepositoryLive.layer
+
+  val testLayer = (Logging.ignore ++ connectionLayer) >>> repoLayer
+
+  override def spec =
+    suite("item repository test with postgres test container")(
+      testM("save items returns their ids") {
+        for {
+          id1 <- ItemRepository.add("first item")
+          id2 <- ItemRepository.add("second item")
+          id3 <- ItemRepository.add("third item")
+
+        } yield (assert(id1)(equalTo(ItemId(1))) && assert(id2)(equalTo(ItemId(2))) && assert(id3)(
+          equalTo(ItemId(3))
+        ))
+      },
+      testM("get all returns 3 items") {
+        for {
+          items <- ItemRepository.getAll()
+        } yield (assert(items)(hasSize(equalTo(3))))
+      },
+      testM("delete first item") {
+        for {
+          _ <- ItemRepository.delete(ItemId(1))
+          item <- ItemRepository.getById(ItemId(1))
+        } yield (assert(item)(isNone))
+      },
+      testM("get item 2") {
+        for {
+          item <- ItemRepository.getById(ItemId(2))
+        } yield (assert(item)(isSome) && assert(item.get.description)(equalTo("second item")))
+      },
+      testM("update item 3") {
+        for {
+          _ <- ItemRepository.update(ItemId(3), Item(ItemId(3), "updated item"))
+          item <- ItemRepository.getById(ItemId(3))
+        } yield (assert(item)(isSome) && assert(item.get.description)(equalTo("updated item")))
+      },
+      
+    ).provideCustomLayerShared(testLayer.orDie) @@ sequential

--- a/src/main/g8/src/test/scala/$package$/repo/postgresql/ConnectionBuilder.scala
+++ b/src/main/g8/src/test/scala/$package$/repo/postgresql/ConnectionBuilder.scala
@@ -1,0 +1,54 @@
+package $package$.repo.postgresql
+
+import zio._
+import java.sql.Connection
+import java.sql.SQLException
+import java.sql.DriverManager
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import zio.blocking._
+import zio.clock._
+import zio.duration._
+import java.util.Properties
+
+trait ConnectionBuilder:
+  def connection: Managed[SQLException, Connection]
+
+object ConnectionBuilder:
+  def connection: ZManaged[Has[ConnectionBuilder], SQLException, Connection] =
+    ZManaged.serviceWithManaged[ConnectionBuilder](_.connection)
+
+final class ConnectionBuilderLive(
+    container: PostgreSQLContainer,
+    blocking: Blocking.Service,
+    clock: Clock.Service,
+  ) extends ConnectionBuilder:
+
+  def connection: Managed[SQLException, Connection] =
+    ZManaged.make(createConnection())(conn => ZIO.effect(conn.close).orDie)
+
+  private def createConnection(): IO[SQLException, Connection] =
+    blocking
+      .effectBlocking(
+        DriverManager.getConnection(
+          container.jdbcUrl,
+          connProperties(container.username, container.password),
+        )
+      )
+      .retry(Schedule.recurs(20) && Schedule.exponential(10.millis))
+      .provide(Has(clock))
+      .refineOrDie { case e: SQLException => e }
+
+  private def connProperties(user: String, password: String): Properties =
+    val props = new Properties
+    props.setProperty("user", user)
+    props.setProperty("password", password)
+    props
+
+object ConnectionBuilderLive:
+  val layer
+      : ZLayer[Has[PostgreSQLContainer] with Blocking with Clock, Nothing, Has[ConnectionBuilder]] =
+    (for {
+      container <- ZIO.service[PostgreSQLContainer]
+      blocking <- ZIO.service[Blocking.Service]
+      clock <- ZIO.service[Clock.Service]
+    } yield ConnectionBuilderLive(container, blocking, clock)).toLayer

--- a/src/main/g8/src/test/scala/$package$/repo/postgresql/PostgresContainer.scala
+++ b/src/main/g8/src/test/scala/$package$/repo/postgresql/PostgresContainer.scala
@@ -1,0 +1,27 @@
+package $package$.repo.postgresql
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import zio._
+import zio.duration._
+import zio.blocking.{ effectBlocking, Blocking }
+
+object PostgresContainer:
+
+  def make(
+      imageName: String = "postgres:alpine"
+    ) =
+    ZManaged.make {
+      effectBlocking {
+        val c = new PostgreSQLContainer(
+          dockerImageNameOverride = Option(imageName).map(DockerImageName.parse)
+        ).configure { a =>
+          a.withInitScript("item_schema.sql")
+          ()
+        }
+        c.start()
+        c
+      }
+    } { container =>
+      effectBlocking(container.stop()).orDie
+    }.toLayer


### PR DESCRIPTION
This branch is based on "add_metrics_config_logging" one because I used config and logging a little bit. So first [this PR](https://github.com/ScalaConsultants/zio-quickstart.g8/pull/12) needs to be merged.

Here was done:
- changed in memory repo for the real one that uses Quill. 
- added test containers to test quill repository logic.
- docker compose that starts postgresql with "items" table.